### PR TITLE
Add 'react-helmet' to declarations

### DIFF
--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,1 +1,2 @@
 declare const graphql: (query: TemplateStringsArray) => void
+declare module 'react-helmet'


### PR DESCRIPTION
We need to declare the module in order to import it in the layout files, etc.
The other solution for this would be to add @types/react-helmet which would be overkill in this case.